### PR TITLE
Add a workflow for deployment

### DIFF
--- a/.github/workflows/.github.yml
+++ b/.github/workflows/.github.yml
@@ -1,0 +1,37 @@
+name: Jekyll site CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the site in the jekyll/builder container
+      run: |
+        docker run \
+        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+    
+#    - name: Archive the site
+#      run: |
+#        zip -r site.zip _site
+
+#    - name: Upload 
+#      uses: actions/upload-artifact@v1
+#      with:
+#        name: site
+#        path: _site
+
+    - name: Deploy
+      uses: AEnterprise/rsync-deploy@v1.0
+      env:
+        DEPLOY_KEY: ${{ secrets.priv_key }}
+        ARGS: "-e -c -r --delete"
+        SERVER_PORT: 22
+        FOLDER: .
+        SERVER_IP: "cgal.geometryfactory.com"
+        USERNAME: "mgimeno"
+        SERVER_DESTINATION: "public_html/test_site"


### PR DESCRIPTION
For now the workflow uploads the files on gf.com/mgimeno. 
I still need to figure out how to properly deploy the site.

@lrineau I think you must authorize actions for this repo or something, and we should add a secret for the ssh key or it will always fail.