### PR TITLE
Add styles for single post content lists and list items

### DIFF
--- a/assets/themes/cgal/main.css
+++ b/assets/themes/cgal/main.css
@@ -657,6 +657,19 @@ a:hover {
   font-size: 1em;
   text-align: justify;
 }
+.single-post-content ul,
+.single-post-content ol {
+  color: #828282;
+  font-size: 1em;
+  text-align: justify;
+  padding-left: 2em;
+}
+
+.single-post-content li {
+  color: #828282;
+  font-size: 1em;
+  text-align: justify;
+}
 .post-comments {
   list-style-type: none;
   margin-left: 0;


### PR DESCRIPTION
Lists (`<ul>`, `<ol>`, `<li>`) in post content (.single-post-content) did not have the same style as paragraphs.color, font size, and alignment were inconsistent.

![image](https://github.com/user-attachments/assets/bf769030-842e-4eb5-b1bd-3ced99160b7b)
